### PR TITLE
refactor!: specify url kwargs using a dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ class CustomerViewSet(beam.ViewSet):
 
     call_component = Component
     call_url = "call/{phone}/"
-    call_url_kwargs = ["phone"]
+    call_url_kwargs = {"phone": "phone"}
 ```
 
 ## Layouts

--- a/src/beam/contrib/autocomplete_light/__init__.py
+++ b/src/beam/contrib/autocomplete_light/__init__.py
@@ -1,12 +1,12 @@
 from typing import List
 
+from beam.components import Component
+from beam.urls import UrlKwargDict
+from beam.views import ComponentMixin
+from beam.viewsets import BaseViewSet
 from dal import autocomplete
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
-
-from beam.components import Component
-from beam.views import ComponentMixin
-from beam.viewsets import BaseViewSet
 
 
 class BaseAutocomplete(ComponentMixin, autocomplete.Select2QuerySetView):
@@ -80,7 +80,7 @@ class AutocompleteMixin(BaseViewSet):
 
     autocomplete_view_class = BaseAutocomplete
     autocomplete_url = "autocomplete/"
-    autocomplete_url_kwargs: List[str] = []
+    autocomplete_url_kwargs: UrlKwargDict = {}
     autocomplete_url_name = None
     autocomplete_verbose_name = _("autocomplete")
 

--- a/src/beam/urls.py
+++ b/src/beam/urls.py
@@ -1,0 +1,41 @@
+from logging import getLogger
+from typing import Callable, Dict, List, Optional, Union
+
+from django.db.models import Model
+from django.http import HttpRequest
+
+logger = getLogger(__name__)
+
+
+undefined = (
+    object()
+)  # sentinel value for attributes not defined or overwritten on the viewset
+
+
+LayoutType = List[List[List[str]]]
+
+
+UrlKwargGetter = Callable[[Optional[Model], Optional[HttpRequest]], Optional[str]]
+"""
+A callable that takes an instance and a request and may return a string.
+"""
+
+
+UrlKwargDict = Dict[str, Union[str, UrlKwargGetter]]
+"""
+A dict used to specify url kwargs
+"""
+
+
+def request_kwarg(name: str) -> UrlKwargGetter:
+    """
+    Return a getter for use in an url_kwargs dict that retrieves a kwarg
+    from the request resolver match.
+    """
+
+    def getter(obj=None, request=None):
+        if request and request.resolver_match and request.resolver_match.kwargs:
+            return request.resolver_match.kwargs.get(name, None)
+        return None
+
+    return getter

--- a/src/beam/views.py
+++ b/src/beam/views.py
@@ -162,11 +162,14 @@ class CreateView(ComponentMixin, CreateWithInlinesMixin, generic.CreateView):
         return super().get_template_names() + ["beam/create.html"]
 
     def get_success_url(self):
-        return self.viewset.links["detail"].reverse(obj=self.object)
+        return self.viewset.links["detail"].reverse(
+            obj=self.object, request=self.request
+        )
 
     def get_success_message(self):
         return _('The {model} "{name}" was added successfully.').format(
-            model=self.model._meta.verbose_name, name=str(self.object),
+            model=self.model._meta.verbose_name,
+            name=str(self.object),
         )
 
     def form_valid(self, form, inlines):
@@ -200,7 +203,8 @@ class UpdateView(ComponentMixin, UpdateWithInlinesMixin, generic.UpdateView):
 
     def get_success_message(self):
         return _('The {model} "{name}" was changed successfully.').format(
-            model=self.model._meta.verbose_name, name=str(self.object),
+            model=self.model._meta.verbose_name,
+            name=str(self.object),
         )
 
     def form_valid(self, form, inlines):
@@ -211,7 +215,9 @@ class UpdateView(ComponentMixin, UpdateWithInlinesMixin, generic.UpdateView):
         return response
 
     def get_success_url(self):
-        return self.viewset.links["detail"].reverse(obj=self.object)
+        return self.viewset.links["detail"].reverse(
+            obj=self.object, request=self.request
+        )
 
 
 class SortableListMixin(ComponentMixin):
@@ -533,7 +539,7 @@ class DeleteView(ComponentMixin, InlinesMixin, generic.DeleteView):
         return super().get_template_names() + ["beam/delete.html"]
 
     def get_success_url(self):
-        return self.viewset.links["list"].reverse()
+        return self.viewset.links["list"].reverse(request=self.request)
 
     def get_success_message(self):
         return _('The {model} "{name}" was deleted successfully.').format(

--- a/src/beam/viewsets.py
+++ b/src/beam/viewsets.py
@@ -15,6 +15,7 @@ from django.views import View
 from .actions import Action
 from .components import BaseComponent, Component, FormComponent, ListComponent
 from .inlines import RelatedInline
+from .urls import UrlKwargDict
 from .views import CreateView, DeleteView, DetailView, ListView, UpdateView
 
 logger = getLogger(__name__)
@@ -119,7 +120,7 @@ class ListMixin(BaseViewSet):
     list_view_class = ListView
     list_url = ""
     list_url_name: str
-    list_url_kwargs: List[str] = []
+    list_url_kwargs: UrlKwargDict = {}
     list_verbose_name = _("list")
 
     list_sort_fields: List[str]
@@ -144,7 +145,7 @@ class CreateMixin(BaseViewSet):
     create_component = FormComponent
     create_view_class = CreateView
     create_url = "create/"
-    create_url_kwargs: List[str] = []
+    create_url_kwargs: UrlKwargDict = {}
     create_url_name: str
     create_verbose_name = _("create")
 
@@ -162,7 +163,7 @@ class UpdateMixin(BaseViewSet):
     update_component = FormComponent
     update_view_class = UpdateView
     update_url = "<str:pk>/update/"
-    update_url_kwargs = ["pk"]
+    update_url_kwargs: UrlKwargDict = {"pk": "pk"}
     update_url_name: str
     update_verbose_name = _("update")
 
@@ -181,7 +182,7 @@ class DetailMixin(BaseViewSet):
     detail_view_class: View = DetailView
     detail_url: str = "<str:pk>/"
     detail_url_name: str
-    detail_url_kwargs: List[str] = ["pk"]
+    detail_url_kwargs: UrlKwargDict = {"pk": "pk"}
     detail_verbose_name = _("detail")
 
     detail_model: Model
@@ -198,7 +199,7 @@ class DeleteMixin(BaseViewSet):
     delete_view_class = DeleteView
     delete_url = "<str:pk>/delete/"
     delete_url_name: str
-    delete_url_kwargs = ["pk"]
+    delete_url_kwargs: UrlKwargDict = {"pk": "pk"}
     delete_verbose_name = _("delete")
 
     delete_model: Model

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,4 +1,4 @@
-from beam.templatetags.beam_tags import get_link_url
+from beam.templatetags.beam_tags import get_link_url, get_url_for_related
 from django.test import TestCase
 from testapp.models import Dragonfly
 from testapp.views import DragonflyViewSet
@@ -29,35 +29,57 @@ class UrlTest(TestCase):
 
     def test_links_that_do_not_require_an_instance(self):
         links = DragonflyViewSet().links
-        self.assertEqual(get_link_url(links["list"]), "/dragonfly/")
-        self.assertEqual(get_link_url(links["create"]), "/dragonfly/create/")
+        self.assertEqual(get_link_url(None, links["list"]), "/dragonfly/")
+        self.assertEqual(get_link_url(None, links["create"]), "/dragonfly/create/")
 
     def test_links_that_do_not_require_an_instance_work_if_one_is_supplied(self):
         links = DragonflyViewSet().links
         instance = Dragonfly(pk=123)
-        self.assertEqual(get_link_url(links["list"], instance), "/dragonfly/")
-        self.assertEqual(get_link_url(links["create"], instance), "/dragonfly/create/")
+        self.assertEqual(get_link_url(None, links["list"], instance), "/dragonfly/")
+        self.assertEqual(
+            get_link_url(None, links["create"], instance), "/dragonfly/create/"
+        )
 
     def test_links_that_require_an_instance(self):
         links = DragonflyViewSet().links
         instance = Dragonfly(pk=123)
-        self.assertEqual(get_link_url(links["detail"], instance), "/dragonfly/123/")
         self.assertEqual(
-            get_link_url(links["update"], instance), "/dragonfly/123/update/"
+            get_link_url(None, links["detail"], instance), "/dragonfly/123/"
         )
         self.assertEqual(
-            get_link_url(links["delete"], instance), "/dragonfly/123/delete/"
+            get_link_url(None, links["update"], instance), "/dragonfly/123/update/"
+        )
+        self.assertEqual(
+            get_link_url(None, links["delete"], instance), "/dragonfly/123/delete/"
         )
 
     def test_links_that_require_an_instance_return_none_if_missing(self):
         links = DragonflyViewSet().links
-        self.assertEqual(get_link_url(links["detail"], None), None)
-        self.assertEqual(get_link_url(links["update"], None), None)
-        self.assertEqual(get_link_url(links["delete"], None), None)
+        self.assertEqual(get_link_url(None, links["detail"], None), None)
+        self.assertEqual(get_link_url(None, links["update"], None), None)
+        self.assertEqual(get_link_url(None, links["delete"], None), None)
 
     def test_component_url_with_extra_context(self):
         instance = Dragonfly(pk=123)
         link = DragonflyViewSet().links["extra"]
         self.assertEqual(
-            get_link_url(link, instance, special="param"), "/dragonfly/extra/123/param/"
+            get_link_url(None, link, instance, special="param"),
+            "/dragonfly/extra/123/param/",
         )
+
+    def test_component_url_kwarg_from_request(self):
+        class request:
+            class resolver_match:
+                kwargs = {"special": "from_request"}
+
+        instance = Dragonfly(pk=123)
+        url = DragonflyViewSet().links["extra"].reverse(instance, request)
+        self.assertEqual(
+            url,
+            "/dragonfly/extra/123/from_request/",
+        )
+
+    def test_get_url_for_related_returns_none_instead_of_raising(self):
+        instance = Dragonfly(pk=123)
+        url = get_url_for_related({}, instance, "extra")
+        self.assertIsNone(url)

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -5,12 +5,13 @@ import django_filters
 from beam import RelatedInline, ViewSet, actions
 from beam.actions import Action, DeleteAction, MassUpdateAction
 from beam.inlines import TabularRelatedInline
+from beam.urls import request_kwarg
 from beam.views import DetailView
 from beam.viewsets import Component
 from django.db.models import QuerySet
 from django.http import HttpResponse
 
-from .models import Dragonfly, ProtectedSighting, Sighting, CascadingSighting
+from .models import CascadingSighting, Dragonfly, ProtectedSighting, Sighting
 
 
 class CsvExportAction(Action):
@@ -89,7 +90,7 @@ class DragonflyViewSet(ViewSet):
     extra_component = ExtraComponent
     extra_view_class = ExtraView
     extra_url = "extra/<str:id>/<str:special>/"
-    extra_url_kwargs = ["id"]
+    extra_url_kwargs = {"id": "id", "special": request_kwarg("special")}
 
 
 class SightingViewSet(ViewSet):


### PR DESCRIPTION
Dict values may be strings or callables that have
access to the instance and an optional request.

This allows preserving url parameters from the request
and makes the whole url parameter part more explicit.

missing: tests for new features