### PR TITLE
refactor!: add template blocks for base, detail and form templates.

### DIFF
--- a/src/beam/contrib/reversion/templates/beam_reversion/version_detail.html
+++ b/src/beam/contrib/reversion/templates/beam_reversion/version_detail.html
@@ -3,12 +3,12 @@
 {% load beam_tags %}
 
 {% block heading %}
-    <h1>
-        {% if heading %}{{ heading }}{% else %}
+    {% if heading %}
+        {{ heading }}
+    {% else %}
         {{ version }}
         <small>{% blocktrans with date=version.revision.date_created %}Version as of {{ date }}{% endblocktrans %}</small>
-        {% endif %}
-    </h1>
+    {% endif %}
 {% endblock %}
 
 {% block below_inlines %}

--- a/src/beam/contrib/reversion/templates/beam_reversion/version_list.html
+++ b/src/beam/contrib/reversion/templates/beam_reversion/version_list.html
@@ -4,14 +4,15 @@
 
 
 {% block heading %}
-    <h1>
-        {% if heading %}{{ heading }}{% else %}
+    {% if heading %}
+        {{ heading }}
+    {% else %}
         {% get_options component.model as options %}
         {{ object }}
         <small class="text-muted">{% trans "history"|capfirst %}</small>
-        {% endif %}
-    </h1>
+    {% endif %}
 {% endblock %}
+
 
 {% block table %}
     <table class="table table-striped">

--- a/src/beam/themes/bootstrap4/templates/beam/base.html
+++ b/src/beam/themes/bootstrap4/templates/beam/base.html
@@ -1,37 +1,84 @@
 {% load beam_tags static %}
 <!doctype html>
 <html lang="en">
+
+
 <head>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    {% block meta %}
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-
-    {% block extra_styles %}{% endblock %}
+        {% block extra_meta %}{% endblock %}
+    {% endblock %}
 
     <title>{% block title %}{% endblock %}</title>
+
+    {% block styles %}
+        {% block bootstrap_styles %}
+            <!-- Bootstrap CSS -->
+            <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+        {% endblock %}
+
+        {% block extra_styles %}{% endblock %}
+    {% endblock %}
+
+    {% block extra_head %}{% endblock %}
+
 </head>
 
-<body class="beam {% if popup %}popup {% endif %}{% block body_classes %}{% endblock %}">
-{% block layout %}
-    {% block navigation %}
-        {% render_navigation %}
-    {% endblock %}
-    {% block messages %}{% include "beam/partials/messages.html" %}{% endblock %}
-    {% block content %}{% endblock %}
-{% endblock %}
 
-<!-- Optional JavaScript -->
-<!-- jQuery first, then Popper.js, then Bootstrap JS -->
-<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-<script src="{% static "beam/js/sortable.min.js" %}"></script>  {# add/remove for formsets #}
-<script src="{% static "beam/js/inlines.js" %}"></script>  {# add/remove for formsets #}
-<script src="{% static "beam/js/add_related.js" %}"></script>  {# add/remove for dynamic add related #}
-<script src="{% static "beam/js/actions.js" %}"></script>  {# add/remove for actions #}
-{% block extra_scripts %}{% endblock %}
+<body class="beam {% if popup %}popup {% endif %}{% block body_classes %}{% endblock %}">
+
+    {% block layout %}
+
+        {% block navigation %}
+            {% render_navigation %}
+        {% endblock %}
+
+        {% block messages_container %}
+            {% if messages %}
+                <div class="container">
+                    {% block messages %}
+                        {% include "beam/partials/messages.html" %}
+                    {% endblock %}
+                </div>
+            {% endif %}
+        {% endblock %}
+
+        {% block content_container %}
+            <div class="container">
+                {% block content %}{% endblock %}
+            </div>
+        {% endblock %}
+
+    {% endblock %}
+
+
+    {% block scripts %}
+        <!-- Optional JavaScript -->
+        {% block jquery %}
+            <!-- jQuery first -->
+            <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+        {% endblock %}
+
+        {% block bootstrap_scripts %}
+            <!-- then Popper.js, then Bootstrap JS -->
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+            <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+        {% endblock %}
+
+        {% block beam_scripts %}
+            <!-- then beam JS -->
+            <script src="{% static "beam/js/sortable.min.js" %}"></script>  {# add/remove for formsets #}
+            <script src="{% static "beam/js/inlines.js" %}"></script>  {# add/remove for formsets #}
+            <script src="{% static "beam/js/add_related.js" %}"></script>  {# add/remove for dynamic add related #}
+            <script src="{% static "beam/js/actions.js" %}"></script>  {# add/remove for actions #}
+        {% endblock %}
+
+        {% block extra_scripts %}{% endblock %}
+
+    {% endblock %}
+
 </body>
 </html>

--- a/src/beam/themes/bootstrap4/templates/beam/delete.html
+++ b/src/beam/themes/bootstrap4/templates/beam/delete.html
@@ -7,13 +7,17 @@
 {% block content %}
     <section class="beam-main">
         <div class="container">
-            {% block heading %}
+            {% block heading_container %}
                 <h1>
-                    {% if heading %}{{ heading }}{% else %}
-                    {% get_options component.model as options %}
-                    {% blocktrans %}Delete {{ object }}{% endblocktrans %}
-                    <small class="text-muted">{{ options.verbose_name|capfirst }}</small>
-                    {% endif %}
+                    {% block heading %}
+                        {% if heading %}
+                            {{ heading }}
+                        {% else %}
+                            {% get_options component.model as options %}
+                            {% blocktrans %}Delete {{ object }}{% endblocktrans %}
+                            <small class="text-muted">{{ options.verbose_name|capfirst }}</small>
+                        {% endif %}
+                    {% endblock %}
                 </h1>
             {% endblock %}
 

--- a/src/beam/themes/bootstrap4/templates/beam/detail.html
+++ b/src/beam/themes/bootstrap4/templates/beam/detail.html
@@ -8,41 +8,55 @@
 {% block extra_styles %}{{ block.super }}{% for inline in inlines %}{{ inline.filterset.form.media.css }}{% for action in inline.actions %}{{ action.get_form.media.css }}{% endfor %}{% endfor %}{% endblock %}
 
 {% block content %}
-    <section class="beam-main">
-        <div class="container">
-            {% block links %}
+    {% block main_container %}
+    <main class="beam-main">
+        {% block main %}
+
+            {% block links_container %}
                 <div class="float-right beam-links">
-                    {% include "beam/partials/links.html" with links=viewset.links link_layout=component.link_layout %}
+                    {% block links %}
+                        {% include "beam/partials/links.html" with links=viewset.links link_layout=component.link_layout %}
+                    {% endblock %}
                 </div>
             {% endblock %}
 
-            {% block heading %}
+            {% block heading_container %}
                 <h1>
-                    {% if heading %}{{ heading }}{% else %}
-                    {% get_options component.model as options %}
-                    {{ object }}
-                    <small class="text-muted">{{ options.verbose_name|capfirst }}</small>
-                    {% endif %}
+                    {% block heading %}
+                        {% if heading %}
+                            {{ heading }}
+                        {% else %}
+                            {% get_options component.model as options %}
+                            {{ object }}
+                            <small class="text-muted">{{ options.verbose_name|capfirst }}</small>
+                        {% endif %}
+                    {% endblock %}
                 </h1>
             {% endblock %}
 
-            <div class="card bg-light mb-4 beam-model-fields">
-                <div class="card-body">
-                <div class="card-text">
-                    {% block details %}
-                        {% include "beam/partials/layout.html" with object=object layout=component.layout fields=component.fields %}
-                    {% endblock %}
+            {% block details_container %}
+                <div class="card bg-light mb-4 beam-model-fields">
+                    <div class="card-body">
+                    <div class="card-text">
+                        {% block details %}
+                            {% include "beam/partials/layout.html" with object=object layout=component.layout fields=component.fields %}
+                        {% endblock %}
+                    </div>
+                    </div>
                 </div>
-                </div>
-            </div>
-        </div>
-    </section>
+            {% endblock %}
+
+        {% endblock %}
+    </main>
+    {% endblock %}
 
     {% block above_inlines %}{% endblock %}
 
     {% block inlines %}
         {% for inline in inlines %}
-            {% include inline.detail_template_name|default:"beam/partials/detail_inline.html" %}
+            {% block inline %}
+                {% include inline.detail_template_name|default:"beam/partials/detail_inline.html" %}
+            {% endblock %}
         {% endfor %}
     {% endblock %}
 

--- a/src/beam/themes/bootstrap4/templates/beam/form.html
+++ b/src/beam/themes/bootstrap4/templates/beam/form.html
@@ -7,80 +7,94 @@
 
 {% block content %}
     <form method="post" enctype="multipart/form-data" novalidate>
+        {% block form %}
         {% csrf_token %}
 
+        {% block main_container %}
+        <main class="beam-main">
+            {% block main %}
 
-        <section class="beam-main">
-            <div class="container">
-                {% block links %}
+                {% block links_container %}
                     <div class="float-right beam-links">
-                        {% include "beam/partials/links.html" with links=viewset.links link_layout=component.link_layout %}
+                        {% block links %}
+                            {% include "beam/partials/links.html" with links=viewset.links link_layout=component.link_layout %}
+                        {% endblock %}
                     </div>
                 {% endblock %}
 
-                {% block heading %}
+                {% block heading_container %}
                     <h1>
-                        {% if heading %}{{ heading }}{% else %}
-                        {% get_options component.model as options %}
-                        {% blocktrans with verbose_name=options.verbose_name %}Create {{ verbose_name }}{% endblocktrans %}
-                        {% endif %}
+                        {% block heading %}
+                            {% if heading %}
+                                {{ heading }}
+                            {% else %}
+                                {% get_options component.model as options %}
+                                {% blocktrans with verbose_name=options.verbose_name %}Create {{ verbose_name }}{% endblocktrans %}
+                            {% endif %}
+                        {% endblock %}
                     </h1>
                 {% endblock %}
 
-                {% block form_buttons_top %}
-                    <div class="container-fluid mb-2">
-                        <div class="row">
-                            <div class="btn-group ml-auto">
+                {% block form_buttons_top_container %}
+                    <div class="clearfix">
+                        <div class="btn-group float-right mb-2">
+                            {% block form_buttons_top %}
                                 <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
-                            </div>
+                            {% endblock %}
                         </div>
                     </div>
                 {% endblock %}
 
-                {% block form_errors %}
+                {% block form_errors_container %}
                     {% if form.non_field_errors %}
                         <div class="alert alert-block alert-danger">
                             <ul class="mb-0">
-                                {{ form.non_field_errors|unordered_list }}
+                                {% block form_errors %}
+                                    {{ form.non_field_errors|unordered_list }}
+                                {% endblock %}
                             </ul>
                         </div>
                     {% endif %}
                 {% endblock %}
 
-                <div class="card bg-light mb-4">
-                    <div class="card-body">
-                        <div class="card-text">
-                            {% block details %}
-                                {% include "beam/partials/form_layout.html" with form=form fields=component.fields layout=component.layout %}
-                            {% endblock %}
+                {% block details_container %}
+                    <div class="card bg-light mb-4">
+                        <div class="card-body">
+                            <div class="card-text">
+                                {% block details %}
+                                    {% include "beam/partials/form_layout.html" with form=form fields=component.fields layout=component.layout %}
+                                {% endblock %}
+                            </div>
                         </div>
                     </div>
-                </div>
-            </div>
-        </section>
+                {% endblock %}
+
+            {% endblock %}
+        </main>
+        {% endblock %}
 
         {% block above_inlines %}{% endblock %}
 
         {% block inlines %}
             {% for inline in inlines %}
-                {% include inline.form_template_name|default:"beam/partials/form_inline.html" %}
+                {% block inline %}
+                    {% include inline.form_template_name|default:"beam/partials/form_inline.html" %}
+                {% endblock %}
             {% endfor %}
         {% endblock %}
 
         {% block below_inlines %}{% endblock %}
 
-        <section>
-            <div class="container">
-                {% block form_buttons %}
-                    <div class="container-fluid mb-2">
-                        <div class="row">
-                            <div class="btn-group ml-auto">
-                                <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
-                            </div>
-                        </div>
-                    </div>
-                {% endblock %}
+        {% block form_buttons_container %}
+            <div class="clearfix">
+                <div class="btn-group float-right mb-2">
+                    {% block form_buttons %}
+                        <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
+                    {% endblock %}
+                </div>
             </div>
-        </section>
+        {% endblock %}
+
+        {% endblock %}
     </form>
 {% endblock %}

--- a/src/beam/themes/bootstrap4/templates/beam/list.html
+++ b/src/beam/themes/bootstrap4/templates/beam/list.html
@@ -11,16 +11,22 @@
     {% get_options component.model as options %}
     <section class="beam-main">
         <div class="container">
-            {% block links %}
+            {% block links_container %}
                 <div class="float-right beam-links">
-                    {% include "beam/partials/links.html" with links=viewset.links link_layout=component.link_layout %}
+                    {% block links %}
+                        {% include "beam/partials/links.html" with links=viewset.links link_layout=component.link_layout %}
+                    {% endblock %}
                 </div>
             {% endblock %}
-            {% block heading %}
+            {% block heading_container %}
                 <h1>
-                    {% if heading %}{{ heading }}{% else %}
-                    {{ options.verbose_name_plural|capfirst }}
-                    {% endif %}
+                    {% block heading %}
+                        {% if heading %}
+                            {{ heading }}
+                        {% else %}
+                            {{ options.verbose_name_plural|capfirst }}
+                        {% endif %}
+                    {% endblock %}
                 </h1>
             {% endblock %}
 

--- a/src/beam/themes/bootstrap4/templates/beam/partials/form_layout.html
+++ b/src/beam/themes/bootstrap4/templates/beam/partials/form_layout.html
@@ -1,63 +1,119 @@
 {% load beam_tags %}
 {% load i18n %}
 
+
 {% if fields and not layout %}
     {% fields_to_layout form.fields as layout %}
 {% elif not fields and not layout %}
     {% fields_to_layout form.fields as layout %}
 {% endif %}
 
+
+{% block layout %}
 {% for row in layout %}
+
+    {% block row %}
     <div class="row">
+        {% block columns %}
         {% for col in row %}
-            <div class="{% if row|length_is:1 %}col-md-12{% elif row|length_is:2 %}col-md-6{% elif row|length_is:3 %}col-md-4{% elif row|length_is:4 %}col-md-3{% endif %}">
+
+            {% block column %}
+            <div class="col">
+                {% block fields %}
                 {% for field in col %}
-                    <div class="row field-group">
-                        {% if field.is_html %}
-                            <div class="col-sm-12 beam-field-{{ field }}">
+
+                    {% block field %}
+                    {% if field.is_html %}
+
+                        {% block html_field_container %}
+                        <div class="beam-field-{{ field }}">
+                            {% block html_field %}
                                 {{ field.content|safe }}
+                            {% endblock %}
+                        </div>
+                        {% endblock %}
+
+                    {% else %}
+
+                        {% get_form_field form field as form_field %}
+                        {% if form_field is None %}
+
+                            {% block detail_field_container %}
+                            <div class="row">
+                                <div class="col-sm-4 text-md-right beam-field-label-{{ field }} ">
+
+                                    {% block detail_field_label %}
+                                        <label>
+                                            {{ form.instance|field_verbose_name:field|capfirst }}
+                                        </label>
+                                    {% endblock %}
+
+                                </div>
+                                <div class="col-sm-8 beam-field-{{ field }} ">
+
+                                    {% block detail_field %}
+                                        {% include "beam/partials/detail_field.html" with object=form.instance field=field %}
+                                    {% endblock %}
+
+                                </div>
                             </div>
-                        {% else %}
-                            {% get_form_field form field as form_field %}
-                            {% if form_field is None %}
-                                <div class="col-sm-4 col-md-4 col-lg-4 text-right beam-field-label-{{ field }} ">
-                                    <label class="col-form-label">
-                                        {{ form.instance|field_verbose_name:field|capfirst }}
-                                    </label>
-                                </div>
-                                <div class="col-sm-8 col-md-8 col-lg-8 beam-field-{{ field }} ">
-                                    <div class="form-group">
-                                        <div class="form-control-plaintext">
-                                            {% include "beam/partials/detail_field.html" with object=form.instance field=field %}
-                                        </div>
-                                    </div>
-                                </div>
-                            {% elif not form_field.is_hidden %}
+                            {% endblock %}
 
-                                {% get_url_for_related form_field.field.queryset.model "create" as create_url %}
-                                {% get_options form_field.field.queryset.model as related_options %}
+                        {% elif not form_field.is_hidden %}
 
-                                <div class="col-sm-4 col-md-4 col-lg-4 text-right beam-field-label-{{ field }}">
-                                    <label class="col-form-label" for="{{ form_field.auto_id }}">
-                                        {{ form_field.label }}<span class="text-muted small">{% if form_field.field.required %}*{% else %}&nbsp;{% endif %}</span>
-                                    </label>
+                            {% get_url_for_related form_field.field.queryset.model "create" as create_url %}
+                            {% get_options form_field.field.queryset.model as related_options %}
+
+                            {% block form_field_container %}
+                            <div class="row field-group">
+                                <div class="col-sm-4 text-md-right beam-field-label-{{ field }}">
+
+                                    {% block form_field_label %}
+                                        <label class="col-form-label" for="{{ form_field.auto_id }}">
+                                            {{ form_field.label }}<span class="text-muted small">{% if form_field.field.required %}*{% else %}&nbsp;{% endif %}</span>
+                                        </label>
+                                    {% endblock %}
+
                                 </div>
 
-                                <div class="col-sm-8 col-md-8 col-lg-8 beam-field-{{ field }}"{% if create_url %}
-                                     data-create-text="{% blocktrans with verbose_name=related_options.verbose_name|capfirst %}Create {{ verbose_name }}{% endblocktrans %}"
-                                     data-create-url="{{ create_url }}?_popup={{ form_field.auto_id }}"
-                                {% endif %}>
-                                    {% include "bootstrap4/field.html" with field=form_field form_show_errors=True %}
+                                <div class="col-sm-8 beam-field-{{ field }}"
+                                        {% if create_url %}
+                                             data-create-text="{% blocktrans with verbose_name=related_options.verbose_name|capfirst %}Create {{ verbose_name }}{% endblocktrans %}"
+                                             data-create-url="{{ create_url }}?_popup={{ form_field.auto_id }}"
+                                        {% endif %}>
+
+                                    {% block form_field %}
+                                        {% include "bootstrap4/field.html" with field=form_field form_show_errors=True %}
+                                    {% endblock %}
+
                                 </div>
+                            </div>
+                            {% endblock %}
 
-
-                            {% endif %}
                         {% endif %}
-                    </div>
-                {% endfor %}
-            </div>
-        {% endfor %}
-        {% for hidden in form.hidden_fields %}{{ hidden }}{% endfor %}
-    </div>
-{% endfor %}
 
+                    {% endif %}
+                    {% endblock %}
+
+                {% endfor %}
+                {% endblock %}
+            </div>
+            {% endblock %}
+
+        {% endfor %}
+        {% endblock %}
+
+    </div>
+    {% endblock %}
+
+{% endfor %}
+{% endblock %}
+
+
+{% block hidden_fields %}
+    {% for hidden in form.hidden_fields %}
+        {% block hidden_field %}
+            {{ hidden }}
+        {% endblock %}
+    {% endfor %}
+{% endblock %}

--- a/src/beam/themes/bootstrap4/templates/beam/partials/layout.html
+++ b/src/beam/themes/bootstrap4/templates/beam/partials/layout.html
@@ -1,39 +1,68 @@
 {% load beam_tags %}
 
+
 {% if not layout %}
     {% fields_to_layout fields as layout %}
 {% endif %}
 
-{% for row in layout %}
-    <div class="row">
-    {% for col in row %}
-        {% if row|length_is:1 %}
-            <div class="col-md-12">
-        {% elif row|length_is:2 %}
-            <div class="col-md-6">
-        {% elif row|length_is:3 %}
-            <div class="col-md-4">
-        {% elif row|length_is:4 %}
-            <div class="col-md-3">
-        {% endif %}
-    <div class="row">
-        {% for field in col %}
-            {% if field.is_html %}
-                <div class="col-sm-12 beam-field-{{ field }}">
-                    {{ field.content|safe }}
-                </div>
-            {% else %}
-                <div class="col-sm-4 col-md-4 col-lg-4 text-md-right font-weight-bold beam-field-label-{{ field }}">
-                    {{ object|field_verbose_name:field|capfirst }}
-                </div>
-                <div class="col-sm-8 col-md-8 col-lg-8 beam-field-{{ field }}">
-                    {% include "beam/partials/detail_field.html" with object=object field=field %}
-                </div>
-            {% endif %}
-        {% endfor %}
-    </div>
-    </div>
-    {% endfor %}
-</div>
-{% endfor %}
 
+{% block layout %}
+{% for row in layout %}
+
+    {% block row %}
+    <div class="row">
+        {% block columns %}
+        {% for col in row %}
+
+            {% block column %}
+            <div class="col">
+                {% block fields %}
+                {% for field in col %}
+
+                    {% block field %}
+                    {% if field.is_html %}
+
+                        {% block html_field_container %}
+                        <div class="beam-field-{{ field }}">
+                            {% block html_field %}
+                                {{ field.content|safe }}
+                            {% endblock %}
+                        </div>
+                        {% endblock %}
+
+                    {% else %}
+
+                        {% block detail_field_container %}
+                        <div class="row">
+                            <div class="col-sm-4 text-md-right font-weight-bold beam-field-label-{{ field }}">
+
+                                {% block detail_field_label %}
+                                    {{ object|field_verbose_name:field|capfirst }}
+                                {% endblock %}
+
+                            </div>
+                            <div class="col-sm-8 beam-field-{{ field }}">
+
+                                {% block detail_field %}
+                                    {% include "beam/partials/detail_field.html" with object=object field=field %}
+                                {% endblock %}
+
+                            </div>
+                        </div>
+                        {% endblock %}
+
+                    {% endif %}
+                    {% endblock %}
+
+                {% endfor %}
+                {% endblock %}
+            </div>
+            {% endblock %}
+
+        {% endfor %}
+        {% endblock %}
+    </div>
+    {% endblock %}
+
+{% endfor %}
+{% endblock %}

--- a/src/beam/themes/bootstrap4/templates/beam/partials/messages.html
+++ b/src/beam/themes/bootstrap4/templates/beam/partials/messages.html
@@ -1,15 +1,30 @@
 {% load i18n %}
+
+
+{% block messages_container %}
 <section class="beam-alerts">
-    <div class="container">
-        {% if messages %}
-            {% for message in messages %}
-                <div class="alert alert-dismissible alert-{% if message.level_tag == 'error' %}danger{% else %}{{ message.level_tag }}{% endif %}" role="alert">
-                    {{ message }}
-                    <button type="button" class="close" data-dismiss="alert" aria-label="{% trans 'Close' %}">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-            {% endfor %}
-        {% endif %}
-    </div>
+
+    {% block messages %}
+    {% for message in messages %}
+
+        {% block message_container %}
+        <div class="alert alert-dismissible alert-{% if message.level_tag == 'error' %}danger{% else %}{{ message.level_tag }}{% endif %}" role="alert">
+
+            {% block message %}
+                {{ message }}
+            {% endblock %}
+
+            {% block buttons %}
+                <button type="button" class="close" data-dismiss="alert" aria-label="{% trans 'Close' %}">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            {% endblock %}
+
+        </div>
+        {% endblock %}
+
+    {% endfor %}
+    {% endblock %}
+
 </section>
+{% endblock %}

--- a/src/beam/themes/bootstrap4/templates/beam/update.html
+++ b/src/beam/themes/bootstrap4/templates/beam/update.html
@@ -5,11 +5,11 @@
 {% block body_classes %}{{ block.super }} beam-update{% if component.model %}{% get_options component.model as options %} beam-update-{{ options.app_label }}-{{ options.model_name }}{% endif %}{% endblock %}
 
 {% block heading %}
-    <h1>
-        {% if heading %}{{ heading }}{% else %}
+    {% if heading %}
+        {{ heading }}
+    {% else %}
         {% get_options component.model as options %}
         {% blocktrans %}Update {{ object }}{% endblocktrans %}
         <small class="text-muted">{{ options.verbose_name|capfirst }}</small>
-        {% endif %}
-    </h1>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
changes:

- base.html
  - wrapped messages and content in div.container

- messages.html
  - removed div.container

- detail.html
  - use main tag instead of section
  - removed div.container inside main
  - renamed blocks
    - links -> links_container
    - heading -> heading_container

- form.html
  - use main tag instead of section
  - removed div.container from
    - main
    - form_buttons_top
    - form_buttons
  - moved mb-2 from div.container to btn-group in
    - form_buttons_top
    - form_buttons
  - removed section around from_buttons
  - renamed blocks
    - links -> links_container
    - heading -> heading_container
    - form_buttons_top -> form_buttons_top_container
    - form_errors -> form_errors_container

- create.html
  - removed h1 from block heading (is now outside)

- partials/layout.html
  - refactored col-xy -> col
  - moved row from field to detail_field_container
  - removed col from html_field_container
  - switched .text-md-right for .text-sm-right

- partials/form_layout.html
  - refactored col-xy -> col
  - moved .row from field to detail_field_container
  - moved .row .field-group to form_field_container
  - removed .col-form-label from detail_field_label
  - removed .form-group and .form-control-plaintext from detail_field
  - removed col from html_field_container
  - switched .text-right for .text-sm-right
  - moved hidden_fields outside layout