### PR TITLE
add ids to detail_inline.html li elements

### DIFF
--- a/src/beam/themes/bootstrap4/templates/beam/partials/detail_inline.html
+++ b/src/beam/themes/bootstrap4/templates/beam/partials/detail_inline.html
@@ -49,7 +49,7 @@
                 {% block inline_items %}
                 {% for object in page.object_list %}
                     {% block inline_item_container %}
-                    <li class="list-group-item bg-light">
+                    <li id="{{ inline.prefix }}-{{ forloop.counter0 }}" class="list-group-item bg-light">
                         {% block inline_item %}
                             {% if actions %}
                                 {% block select_item %}

--- a/src/beam/themes/bootstrap4/templates/beam/partials/detail_inline_tabular.html
+++ b/src/beam/themes/bootstrap4/templates/beam/partials/detail_inline_tabular.html
@@ -33,7 +33,7 @@
             <tbody>
                 {% for object in page.object_list %}
                     {% block inline_item_container %}
-                    <tr>
+                    <tr id="{{ inline.prefix }}-{{ object.id }}">
                         {% if actions %}
                             <td>
                                 {% block select_item %}{{ block.super }}{% endblock %}

--- a/src/beam/themes/bootstrap4/templates/beam/partials/detail_inline_tabular.html
+++ b/src/beam/themes/bootstrap4/templates/beam/partials/detail_inline_tabular.html
@@ -33,7 +33,7 @@
             <tbody>
                 {% for object in page.object_list %}
                     {% block inline_item_container %}
-                    <tr id="{{ inline.prefix }}-{{ object.id }}">
+                    <tr id="{{ inline.prefix }}-{{ forloop.counter0 }}">
                         {% if actions %}
                             <td>
                                 {% block select_item %}{{ block.super }}{% endblock %}


### PR DESCRIPTION
I kept the logic of the ids in the detail views same as the form/update views:

- forloop counter for regular inlines
- object id for tabular inlines

Although I do not understand why it is different in the first place.