### PR TITLE
chore: requrie django-crispy-forms <2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages = find:
 include_package_data = True
 install_requires =
     django >= 3.2
-    django-crispy-forms >=1.9
+    django-crispy-forms >=1.9, <2.0
     django-extra-views >=0.12.0
     django-filter >= 2.0
 


### PR DESCRIPTION
the template structure in 2.0 has changed
so for now we need to use versions <2.0