### PR TITLE
feat: preserve search query and filters whilst using the respective other

### DIFF
--- a/src/beam/themes/bootstrap4/templates/beam/list.html
+++ b/src/beam/themes/bootstrap4/templates/beam/list.html
@@ -44,6 +44,9 @@
         {% block search %}
             {% if view.search_fields %}
                 <form method="get" id="search-form">
+
+                    {% preserve_get_params_as_hidden_inputs ignore_params=view.page_kwarg q="" %}
+
                     <div class="input-group">
                         <input name="q" type="text" value="{{ search_query }}" class="form-control"
                                placeholder="{% trans 'Search the list below' %}"
@@ -52,7 +55,7 @@
                         <div class="input-group-append">
 
                             {% if search_query %}
-                                <a href="{{ request.path }}"
+                                <a href="{{ request.path }}{% preserve_query_string ignore_params=view.page_kwarg q="" %}"
                                    class="btn btn-outline-secondary">{% trans "Clear" %}</a>
                             {% endif %}
                             <input type="submit" class="btn btn-outline-primary" value="{% trans 'Search' %}"/>
@@ -62,7 +65,7 @@
             {% endif %}
         {% endblock %}
         {% block filters %}
-            {% include "beam/partials/filters.html" %}
+            {% include "beam/partials/filters.html" with page_param=view.page_kwarg %}
         {% endblock %}
 
         {% if actions %}
@@ -90,11 +93,11 @@
                             {% with field_name=field|stringformat:"s" %}{# cast to string to support virtual fields #}
                                 {% if field_name in sortable_fields %}
                                     {# fixme text-nowrap only if there is a chance to fit this?  #}
-                                    <a class="text-nowrap" href="{% sort_link field_name sorted_fields %}">
+                                    <a class="text-nowrap" href="{% sort_link field_name sorted_fields page_param=view.page_kwarg %}">
                                         {{ component.model|field_verbose_name:field|capfirst }}&nbsp;{% if field_name in sorted_fields %}<i class="fa fa-caret-up"></i>{% elif "-"|add:field_name in sorted_fields %}<i class="fa fa-caret-down"></i>{% endif %}
                                     </a>
                                     {% if field_name in sorted_fields or "-"|add:field_name in sorted_fields %}
-                                        <a title="{% trans "reset sort" %}" href="{% sort_link "" "" %}"><i class="fa fa-remove"></i></a>
+                                        <a title="{% trans "reset sort" %}" href="{% sort_link "" "" page_param=view.page_kwarg %}"><i class="fa fa-remove"></i></a>
                                     {% endif %}
                                 {% else %}
                                     {{ component.model|field_verbose_name:field|capfirst }}

--- a/src/beam/themes/bootstrap4/templates/beam/partials/filters.html
+++ b/src/beam/themes/bootstrap4/templates/beam/partials/filters.html
@@ -1,4 +1,7 @@
 {% load i18n %}
+{% load beam_tags %}
+
+
 {% if filterset %}
     <div class="beam-filterset mt-3 mb-3">
         <div class="input-group">
@@ -11,16 +14,24 @@
         </div>
         <div class="beam-filterset__collapse collapse {% if filterset.form.has_changed %}show{% endif %} mt-3"
              id="filter-form-container">
+
             <form method="get" id="{{ filterset.form.prefix }}-form" class="beam-filterset__form">
+
                 {% include "beam/partials/form_layout.html" with form=filterset.form %}
-                <input type="hidden" name="_has_beam_filter" value="1">
+
+                {% build_ignore_params filterset.form page_param as ignore_params %}
+
+                {% preserve_get_params_as_hidden_inputs ignore_params=ignore_params _has_beam_filter="1" %}
+
                 <div class="input-group">
-                    <a href="{{ request.path }}"
+                    <a href="{{ request.path }}{% preserve_query_string ignore_params=ignore_params _has_beam_filter="0" %}"
                        class="btn btn-outline-secondary">{% trans "Clear filters" %}</a>
                     <input type="submit" class="btn btn-outline-primary ml-auto"
                            value="{% trans 'Filter' %}"/>
                 </div>
+
             </form>
+
         </div>
     </div>
 {% endif %}


### PR DESCRIPTION
This should solve the problem, that the search query is lost when using a filter or vise versa.

tests are missing atm

should work with sorting, filtering and searching inlines (due to flexible `page_param`)

one could argue to use a default for `page_param` like `page` to be more backwards compatible (especially `sort_link` tag)

and one could argue to use another name for "form", to prevent collisions with kwargs